### PR TITLE
Fix undeclared parameters

### DIFF
--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -47,7 +47,7 @@ class AuthController extends Controller
             $data .= ':' . $responseData['channel_data'];
         }
 
-        $responseData['auth'] = $this->container->getParameter('lopi_pusher.key') . ':' . $this->getCode($data);
+        $responseData['auth'] = $this->container->getParameter('lopi_pusher.config')['key'] . ':' . $this->getCode($data);
 
         return new Response(json_encode($responseData), 200, array('Content-Type' => 'application/json'));
     }
@@ -61,6 +61,6 @@ class AuthController extends Controller
      */
     private function getCode($data)
     {
-        return hash_hmac('sha256', $data, $this->container->getParameter('lopi_pusher.secret'));
+        return hash_hmac('sha256', $data, $this->container->getParameter('lopi_pusher.config')['secret']);
     }
 }


### PR DESCRIPTION
Hello,

I am experiencing a strange issue using a custom Authentication service. When Pusher calls the route it returns an error because it can't find a ```lopi_pusher.key``` and ```lopi_pusher.secret````parameters in container.

This PR solves the issue. 